### PR TITLE
UI: Check for environment role before hitting API

### DIFF
--- a/apps/ui/src/server/config.ts
+++ b/apps/ui/src/server/config.ts
@@ -36,6 +36,7 @@ const serverConfig = {
     port: Number(process.env.LISTEN_PORT) || 8080
   },
   mode: (process.env.MODE || 'server') as Mode,
+  requiredRoles: [process.env.ENVIRONMENT || 'dev'],
   ssrOnly: !!(process.env.SSR_ONLY && process.env.SSR_ONLY.match(/(yes|true)/i))
 };
 

--- a/apps/ui/src/server/graphql.ts
+++ b/apps/ui/src/server/graphql.ts
@@ -105,7 +105,9 @@ type V1BirthStatus {
 `;
 
 const hasAccess = (roles: string[], resource: string): boolean => (
-  roles.includes(resource)
+  [ ...config.requiredRoles, resource ].reduce((
+    (acc, cur) => acc && roles.includes(cur)
+  ), true)
 );
 
 const Redact = (roles: string[]) => (obj: object) => (key: string, role: string) => {


### PR DESCRIPTION
We break down permissions by staging environment so we should check the
user has the right role before making a request to the API.

In the long run it would be nice to also check for this in React so that
we don't even hit GraphQL unnecessarily.