### PR TITLE
feature: send feedback emails to lev-service

### DIFF
--- a/apps/ui/src/common/config.ts
+++ b/apps/ui/src/common/config.ts
@@ -1,7 +1,8 @@
 import pkg from '../../package.json';
 
 const config = {
-  name: pkg.name
+  name: pkg.name,
+  feedbackEmail: process.env.FEEDBACK_EMAIL
 };
 
 export default config;

--- a/apps/ui/src/common/pages/feedback.tsx
+++ b/apps/ui/src/common/pages/feedback.tsx
@@ -2,6 +2,7 @@ import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { Form, email, required } from '@not-govuk/components';
+import config from '../config';
 
 export const title = 'Feedback';
 
@@ -12,20 +13,9 @@ const Page: FC<PageProps> = props => (
     </Helmet>
     <div className="govuk-grid-column-two-thirds">
       <h1>Feedback</h1>
-      <Form action="/feedback" method="get">
-        <Form.TextInput
-          name="email"
-          label={<h4>Email address</h4>}
-          hint="An e-mail address so that we can reply to you"
-          validators={[required(), email()]}
-        />
-        <Form.Textarea
-          name="message"
-          label={<h4>Message</h4>}
-          validators={[required()]}
-        />
-        <Form.Submit value="Submit" />
-      </Form>
+      <p>If you have an idea for a new feature, or want to provide feedback on
+      any aspect of the service, please let us know.</p>
+      <a className="govuk-button" href={"mailto:" + config.feedbackEmail + "?subject=LEV Service Feedback"}>Click here to send feedback</a>
     </div>
   </div>
 );


### PR DESCRIPTION
This ticket can't be fully completed at present as we require a mail server to be set up. I attempted to implement a quick-fix by changing the form submit button to a mailto hyperlink instead, however I am unable to get the React code to access the HTML elements or their properties in order to populate the email. Instead we have decided to remove the HTML form and use the hyperlink to populate an email address and subject, and allow the user to enter the email body manually. The email address is populated using environment variables from the levops repo.